### PR TITLE
Ignore CLAUDE.md file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+CLAUDE.md


### PR DESCRIPTION
Lots of people use claude-code these days. You can either commit the CLAUDE.md file to the repo or ignore it (and (re)generate it, when you need it). Let's start with ignoring it for now. We can always add it later.