### PR TITLE
Update README to use .env instead of .env.local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ cd auto_rfp
 pnpm install
 
 # 3. Copy environment file and configure
-cp .env.example .env.local
-# Edit .env.local with your configuration
+cp .env.example .env
+# Edit .env with your configuration
 
 # 4. Set up database
 pnpm prisma generate
@@ -66,7 +66,7 @@ pnpm dev
 
 ### Environment Variables
 
-Create a `.env.local` file with these variables:
+Create a `.env` file with these variables:
 
 ```bash
 # Database

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pnpm install
 
 ### 3. Environment Setup
 
-Create a `.env.local` file in the root directory:
+Create a `.env` file in the root directory:
 
 ```bash
 # Database

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -18,7 +18,7 @@ export function validateEnv() {
       Missing required environment variables:
       ${missingVars.map(v => `- ${v.key}`).join('\n      ')}
       
-      Please set these in your .env.local file
+      Please set these in your .env file
     `);
     return false;
   }

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   // Configure environment variables that will be available on both server and client side
   env: {
     // You will need to set LLAMACLOUD_API_KEY in your deployment environment
-    // or in a .env.local file that's not committed to version control
+    // or in a .env file that's not committed to version control
     LLAMACLOUD_API_KEY: process.env.LLAMACLOUD_API_KEY,
     // Internal API key for internal users
     LLAMACLOUD_API_KEY_INTERNAL: process.env.LLAMACLOUD_API_KEY_INTERNAL,


### PR DESCRIPTION
Prisma needs the config in a .env file. We could have two files or point prisma to the .env.local file. But the simplest solution is to just use a/the .env file instead of a/the .env.local file.